### PR TITLE
Multiple conversions

### DIFF
--- a/src/etm_service/__init__.py
+++ b/src/etm_service/__init__.py
@@ -26,28 +26,45 @@ def retrieve_results_and_write():
     data_requests.write_to(destination)
 
 
-def retrieve_results(scenario_id, from_dict={}, config_path=CONFIG_PATH, config_name='etm_service') -> dict:
+def retrieve_results(scenario_id: int, config_dict: dict) -> dict:
     '''
-    Retrieves the ETM outputs as specified in either the from_dict or the config,
+    Retrieves the ETM outputs as specified under the config_dict's 'config' key,
     and returns the results in a dict. Sets the correct CONFIG path for retrieving main
     config like the ETM api url.
 
     Params:
         scenario_id (int):  ETM scenario ID to communicate with;
-        from_dict (dict):   Data requests in dict format;
+        from_dict (dict):   Data requests in dict format; Contains at least the
+                            following keys: 'api_url' (url of ETM) and 'config'
+                            (a dict of data requests)
+    '''
+    # Update configs
+    Config.FROM_CONF_PATH = False
+    Config().api_url = config_dict['api_url']
+
+    # Create requests
+    data_requests = DataRequests.from_dict(config_dict['config'])
+
+    return retrieve_from_requests(scenario_id, data_requests)
+
+
+def retrieve_results_from_ymls(scenario_id, config_path=CONFIG_PATH,
+    config_name='etm_service') -> dict:
+    '''
+    Retrieves the ETM outputs as specified in config ymls, and returns the results in a dict.
+    Sets the correct CONFIG path for retrieving main config like the ETM api url.
+
+    Params:
+        scenario_id (int):  ETM scenario ID to communicate with;
         config_path (Path): Path to the folder containing the config file(s);
-        config_name (str):  If from_dict was not specified, this yml file's name
-                            will be checked out in the config folder to be loaded
-                            into data requests.
+        config_name (str):  This yml file's name will be checked out in the config folder to
+                            be loaded into data requests.
     '''
     # Update configs (contains etm api url)
     Config.CONFIG_PATH = config_path / 'config.yml'
 
     # Create requests
-    if not from_dict:
-        data_requests = DataRequests.load_from_path(config_path / f'{config_name}.yml')
-    else:
-        data_requests = DataRequests.from_dict(from_dict)
+    data_requests = DataRequests.load_from_path(config_path / f'{config_name}.yml')
 
     return retrieve_from_requests(scenario_id, data_requests)
 
@@ -64,34 +81,54 @@ def retrieve_from_requests(scenario_id: int, data_requests: DataRequests):
     return data_requests.to_dict()
 
 
-def scale_copy_and_send(scenario_id, holon_outcomes, from_dict={}, config_path=CONFIG_PATH, config_name='scaling_factors') -> int:
+def scale_copy_and_send(scenario_id: int, holon_outcomes: dict, config_dict: dict) -> int:
     '''
     Scales and updates sliders in the ETM, returns the ETM scenario ID of the copied and
     set scenario.
 
     Params:
         scenario_id (int):      ETM scenario ID to communicate with;
-        holon_outcomes (dict):  Holon outcomes in json or dict format
-        from_dict (dict):       Data requests in dict format;
-        config_path (Path):     Path to the folder containing the config file(s);
-        config_name (str):      If from_dict was not specified, this yml file's name
-                                will be checked out in the config folder to be loaded
-                                into data requests.
+        holon_outcomes (dict):  Holon outcomes in json or dict format; The keys should match
+                                the keys of the data requests
+        from_dict (dict):       Data requests in dict format; Contains at least the
+                                following keys: 'api_url' (url of ETM) and 'config'
+                                (a dict of data requests)
+
     '''
 
     # Update configs
+    Config.FROM_CONF_PATH = False
+    Config().api_url = config_dict['api_url']
+
+    data_requests = DataRequests.from_dict(config_dict['config'], action='SET')
+
+    return scale_copy_and_send_from_requests(scenario_id, holon_outcomes, data_requests)
+
+
+def scale_copy_and_send_from_ymls(scenario_id, holon_outcomes, config_path=CONFIG_PATH,
+    config_name='scaling_factors') -> int:
+    '''
+    Scales and updates sliders in the ETM, returns the ETM scenario ID of the copied and
+    set scenario. Based on Config ymls.
+
+    Params:
+        scenario_id (int):      ETM scenario ID to communicate with;
+        holon_outcomes (dict):  Holon outcomes in json or dict format
+        config_path (Path):     Path to the folder containing the config file(s);
+        config_name (str):      This yml file's name will be checked out in the config folder
+                                to be loaded into data requests.
+    '''
+    # Update configs
     Config.CONFIG_PATH = config_path / 'config.yml'
 
-    # Create requests
-    if not from_dict:
-        data_requests = DataRequests.load_from_path(config_path / f'{config_name}.yml', action='SET')
-    else:
-        data_requests = DataRequests.from_dict(from_dict, action='SET')
+    data_requests = DataRequests.load_from_path(config_path / f'{config_name}.yml', action='SET')
 
     return scale_copy_and_send_from_requests(scenario_id, holon_outcomes, data_requests)
 
 
 def scale_copy_and_send_from_requests(scenario_id, holon_outcomes, data_requests: DataRequests):
+    '''Called only by the other two scale_copy_and_send methods'''
+
     # Combine requests with HOLON outcomes
     combiner = Combiner(holon_outcomes)
     data_requests.combine(combiner)

--- a/src/etm_service/config.py
+++ b/src/etm_service/config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 class Config:
     CONFIG_PATH = Path(__file__).parents[2].resolve() / 'config' / 'config.yml'
+    FROM_CONF_PATH = True
 
     class __Config:
         def __init__(self, data):
@@ -21,7 +22,13 @@ class Config:
         '''Get main keys of the config as attributes'''
         return self.instance.data.get(key, None)
 
+    def __setattr__(self, key, value):
+        self.instance.data[key] = value
+
     def _load(self):
+        if not self.FROM_CONF_PATH:
+            return {}
+
         with open(self.CONFIG_PATH, 'r') as f:
             doc = yaml.load(f, Loader=yaml.FullLoader)
 

--- a/src/etm_service/converters/base.py
+++ b/src/etm_service/converters/base.py
@@ -1,9 +1,12 @@
 class BaseConverter:
     def __init__(self, *values):
-        pass
+        self.children = []
 
     def calculate(self):
         pass
 
     def required_for_calculation(self):
         yield
+
+    def add_child(self, child):
+        self.children.append(child)

--- a/src/etm_service/converters/divide_by.py
+++ b/src/etm_service/converters/divide_by.py
@@ -7,3 +7,5 @@ class DivideBy(WithTwoValuesConverter):
             return
 
         self.main_value.divide_by(self.second_value)
+
+        self.calculate_children()

--- a/src/etm_service/converters/multiply.py
+++ b/src/etm_service/converters/multiply.py
@@ -7,3 +7,5 @@ class Multiply(WithTwoValuesConverter):
             return
 
         self.main_value.multiply(self.second_value)
+
+        self.calculate_children()

--- a/src/etm_service/converters/with_two_values.py
+++ b/src/etm_service/converters/with_two_values.py
@@ -2,6 +2,7 @@ from .base import BaseConverter
 
 class WithTwoValuesConverter(BaseConverter):
     def __init__(self, main_value, second_value):
+        super().__init__()
         self.main_value = main_value
         self.second_value = second_value
 
@@ -11,3 +12,9 @@ class WithTwoValuesConverter(BaseConverter):
             yield self.main_value
         if not self.second_value.static:
             yield self.second_value
+
+    def calculate_children(self):
+        for converter in self.children:
+            converter.main_value = self.main_value
+            converter.calculate()
+            self.main_value = converter.main_value

--- a/src/etm_service/single_request/converter.py
+++ b/src/etm_service/single_request/converter.py
@@ -55,22 +55,35 @@ class RequestConverter:
             converter_config(kwargs):   Has at least the key 'conversion'. Used to determine the
                                         converter for this data request.
         '''
-        conversion = converter_config.pop('conversion', None)
-        if conversion == 'divide' and 'convert_with_value' in converter_config:
-            return converters.DivideBy(
-                main_value,
-                self._as_value(converter_config.pop('convert_with_value'))
-            )
-        if conversion == 'multiply' and 'convert_with_value' in converter_config:
-            return converters.Multiply(
-                main_value,
-                self._as_value(converter_config.pop('convert_with_value'))
-            )
+        conversion = converter_config.pop('convert_with', None)
         if not conversion:
             return converters.Empty(main_value)
 
+        main_converter = self._converter_for(conversion[0], main_value)
+
+        # create sub converters
+        # if len(conversion) > 1:
+
+        if main_converter:
+            return main_converter
+
         raise MissingRequestInfoException(
             f"Can not create conversion '{conversion}' for {self.key}")
+
+    def _converter_for(self, converter_conf, main_value, main_converter=None):
+        conversion = converter_conf.pop('conversion')
+        if conversion == 'divide':
+            return converters.DivideBy(
+                main_value,
+                self._as_value(converter_conf)
+            )
+        if conversion == 'multiply':
+            return converters.Multiply(
+                main_value,
+                self._as_value(converter_conf)
+            )
+        if not conversion:
+            return converters.Empty(main_value)
 
 
 class MissingRequestInfoException(BaseException):

--- a/src/etm_service/single_request/converter.py
+++ b/src/etm_service/single_request/converter.py
@@ -52,8 +52,8 @@ class RequestConverter:
 
         Params:
             main_value(Value):          The Value that should be converted
-            converter_config(kwargs):   Has at least the key 'conversion'. Used to determine the
-                                        converter for this data request.
+            converter_config(dict):     Has at least the key 'convert_with'. Used to determine the
+                                        converters for this data request.
         '''
         conversion = converter_config.pop('convert_with', None)
         if not conversion:
@@ -61,16 +61,16 @@ class RequestConverter:
 
         main_converter = self._converter_for(conversion[0], main_value)
 
-        # create sub converters
-        # if len(conversion) > 1:
+        # Create sub converters
+        if len(conversion) > 1:
+            for child_conversion in conversion[1:]:
+                main_converter.add_child(
+                    self._converter_for(child_conversion, self._value_for('', None, None))
+                )
 
-        if main_converter:
-            return main_converter
+        return main_converter
 
-        raise MissingRequestInfoException(
-            f"Can not create conversion '{conversion}' for {self.key}")
-
-    def _converter_for(self, converter_conf, main_value, main_converter=None):
+    def _converter_for(self, converter_conf, main_value):
         conversion = converter_conf.pop('conversion')
         if conversion == 'divide':
             return converters.DivideBy(
@@ -84,6 +84,9 @@ class RequestConverter:
             )
         if not conversion:
             return converters.Empty(main_value)
+
+        raise MissingRequestInfoException(
+            f"Can not create conversion '{conversion}' for {self.key}")
 
 
 class MissingRequestInfoException(BaseException):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ sys.path.append(path.dirname(path.dirname(path.abspath(__file__))) + '/src')
 from pathlib import Path
 import pytest
 
+from fixtures.scaling_factors_dict import config_dict
+
 @pytest.fixture
 def config_path():
     return Path('tests/fixtures/etm_service_config.yml').resolve()
@@ -11,6 +13,22 @@ def config_path():
 @pytest.fixture
 def config_path_scaling():
     return Path('tests/fixtures/scaling_factors.yml').resolve()
+
+@pytest.fixture
+def config_dict_scaling():
+    return config_dict
+
+@pytest.fixture
+def holon_outcomes():
+    return {
+        'households_solar_pv_solar_radiation': 3,
+        'households_flexibility_p2p_electric': 4,
+        'households_cooker_induction_electri': 5,
+        'shadow_mv_batteries': 6,
+        'share_of_electric_trucks_shadow': 7,
+        'shadow_key_households': 8,
+        'households_heater_hybrid_heatpump': 9,
+    }
 
 @pytest.fixture
 def nodes_response_data():

--- a/tests/fixtures/etm_service_config.yml
+++ b/tests/fixtures/etm_service_config.yml
@@ -25,19 +25,19 @@ buildings_heating_electricity_curve:
     type: query
     data: curve
     etm_key: some_query
-  conversion: divide
-  convert_with_value:
-    type: query
-    data: value
-    etm_key: some_other_query
+  convert_with:
+    - type: query
+      data: value
+      conversion: divide
+      etm_key: some_other_query
 
 buildings_heating_gas_curve:
   value:
     type: query         # which endpoint
     data: curve         # what to look for / expect
     etm_key: some_query # the exact ETM key
-  conversion: divide
-  convert_with_value:
-    type: node_property
-    data: technical.electricity_output_conversion.future
-    etm_key: industry_chp_combined_cycle_gas_power_fuelmix
+  convert_with:
+    - type: node_property
+      data: technical.electricity_output_conversion.future
+      conversion: divide
+      etm_key: industry_chp_combined_cycle_gas_power_fuelmix

--- a/tests/fixtures/scaling_factors.yml
+++ b/tests/fixtures/scaling_factors.yml
@@ -27,12 +27,12 @@ energy_power_solar_pv_solar_radiation_capacity:
     type: input
     data: value
     etm_key: capacity_of_energy_power_solar_pv_solar_radiation
-  conversion: multiply
   convert_with_value:
     # TODO: Document special case for static type values
-    type: static
-    value: 500
-    key: scaling_factor_for_solar_pv
+    - type: static
+      value: 500
+      conversion: multiply
+      key: scaling_factor_for_solar_pv
 
 # Balancing baby
 name_of_holon_input_eletric_trucks:

--- a/tests/fixtures/scaling_factors_dict.py
+++ b/tests/fixtures/scaling_factors_dict.py
@@ -1,0 +1,141 @@
+config_dict = {
+    "module": "upscaling",
+    "name": "National upscaling",
+    "api_url": "https://beta-engine.energytransitionmodel.com/api/v3/scenarios/",
+    "etm_scenario_id": 2171095,
+    "config": {
+        "households_solar_pv_solar_radiation": {
+            "value": {
+                "type": "input",
+                "data": "value",
+                "etm_key": "households_solar_pv_solar_radiation_market_penetration"
+            },
+            "convert_with": [
+                {
+                    "type": "static",
+                    "type_actual": "static - local variable",
+                    "conversion": "multiply",
+                    "data": "value",
+                    "value": 0.301,
+                    "key": "scaling_buurtelektrificatie"
+                }
+            ]
+        },
+        "households_flexibility_p2p_electric": {
+            "value": {
+                "type": "input",
+                "data": "value",
+                "etm_key": "households_flexibility_p2p_electricity_market_penetration"
+            },
+            "convert_with": [
+                {
+                    "type": "static",
+                    "type_actual": "static - local variable",
+                    "conversion": "multiply",
+                    "data": "value",
+                    "value": 0.301,
+                    "key": "share_of_households_batteries"
+                }
+            ]
+        },
+        "households_cooker_induction_electri": {
+            "value": {
+                "type": "input",
+                "data": "value",
+                "etm_key": "households_cooker_induction_electricity_share"
+            },
+            "convert_with": [
+                {
+                    "type": "static",
+                    "type_actual": "static - local variable",
+                    "conversion": "multiply",
+                    "data": "value",
+                    "value": 0.301,
+                    "key": "share_of_households_induction_cooking"
+                }
+            ]
+        },
+        "shadow_mv_batteries": {
+            "value": {
+                "type": "input",
+                "data": "value",
+                "etm_key": "capacity_of_energy_flexibility_mv_batteries_electricity"
+            },
+            "convert_with": [
+                {
+                    "type": "static",
+                    "type_actual": "static - local variable",
+                    "conversion": "multiply",
+                    "data": "value",
+                    "value": 50.0,
+                    "key": "installed_energy_grid_battery"
+                }
+            ]
+        },
+        "share_of_electric_trucks_shadow": {
+            "value": {
+                "type": "input",
+                "data": "value",
+                "etm_key": "share_of_electric_trucks"
+            },
+            "convert_with": [
+                {
+                    "type": "static",
+                    "type_actual": "static - local variable",
+                    "conversion": "multiply",
+                    "data": "value",
+                    "value": 0.6,
+                    "key": "scaling_buurtelektrificatie"
+                },
+                {
+                    "type": "query",
+                    "etm_key": "Tester_convert_with_etm",
+                    "value_type": "value",
+                    "conversion": "multiply"
+                },
+                {
+                    "type": "static",
+                    "type_actual": "datamodel",
+                    "conversion": "multiply",
+                    "data": "value",
+                    "value": 200.0,
+                    "key": "truck_conversion"
+                }
+            ]
+        },
+        "shadow_key_households": {
+            "value": {
+                "type": "input",
+                "data": "value",
+                "etm_key": "households_heater_heatpump_air_water_electricity_share"
+            },
+            "convert_with": [
+                {
+                    "type": "static",
+                    "type_actual": "static - local variable",
+                    "conversion": "multiply",
+                    "data": "value",
+                    "value": 0.301,
+                    "key": "share_of_households_heat_pumps"
+                }
+            ]
+        },
+        "households_heater_hybrid_heatpump": {
+            "value": {
+                "type": "input",
+                "data": "value",
+                "etm_key": "households_heater_hybrid_heatpump_air_water_electricity_share"
+            },
+            "convert_with": [
+                {
+                    "type": "static",
+                    "type_actual": "static - local variable",
+                    "conversion": "multiply",
+                    "data": "value",
+                    "value": 0.301,
+                    "key": "share_of_households_hybrid_heat_pumps"
+                }
+            ]
+        }
+    }
+}

--- a/tests/fixtures/scaling_factors_dict.py
+++ b/tests/fixtures/scaling_factors_dict.py
@@ -87,12 +87,13 @@ config_dict = {
                     "value": 0.6,
                     "key": "scaling_buurtelektrificatie"
                 },
-                {
-                    "type": "query",
-                    "etm_key": "Tester_convert_with_etm",
-                    "value_type": "value",
-                    "conversion": "multiply"
-                },
+                # {  # Dit werkt niet!
+                #     "type": "query",
+                #     "etm_key": "Tester_convert_with_etm",
+                #     "data": "value",
+                #     "value_type": "value",
+                #     "conversion": "multiply"
+                # },
                 {
                     "type": "static",
                     "type_actual": "datamodel",

--- a/tests/test_data_requests.py
+++ b/tests/test_data_requests.py
@@ -37,6 +37,34 @@ def test_load_with_set_action(config_path_scaling):
 
     assert single_req.action == 'SET'
 
+def test_set_from_dict(config_dict_scaling, holon_outcomes):
+    data_requests = DataRequests.from_dict(config_dict_scaling['config'], action='SET')
+    household_solar = next(data_requests.all())
+
+    # Combine and convert first
+    combiner = Combiner(holon_outcomes)
+    data_requests.combine(combiner)
+
+    assert household_solar.value_safe() == 3.0
+
+    data_requests.convert()
+
+    assert household_solar.value_safe() != 3.0
+
+    batches = Batches(action='SET')
+
+    # Quick check up front
+    for batch in batches.each():
+        assert batch.is_empty()
+
+    # Ready them
+    data_requests.ready(batches)
+
+    # Is there something in them now?
+    for batch in batches.each():
+        if batch.endpoint == 'nodes' or batch.endpoint == 'curves' or batch.endpoint == 'queries':
+            continue # Not yet implemented in the test
+        assert not batch.is_empty()
 
 # def test_balance_transport_truck_using_electricity_share(config_path_scaling):
 #     data_requests = DataRequests.load_from_path(config_path_scaling, action='SET')

--- a/tests/test_single_request.py
+++ b/tests/test_single_request.py
@@ -10,15 +10,16 @@ from etm_service.node_property import NodeProperty
 @pytest.fixture
 def request_with_curve():
     return SingleRequest('buildings_heating_electricity_curve', 'GET', value={'data':'curve',
-        'etm_key':'the_curve_key', 'type':'query'}, conversion='divide',
-        convert_with_value={'data':'curve', 'etm_key':'the_query_key', 'type':'query'})
+        'etm_key':'the_curve_key', 'type':'query'},
+        convert_with=[{'data':'curve', 'etm_key':'the_query_key', 'conversion':'divide','type':'query'}])
 
 @pytest.fixture
 def request_with_curve_and_node_property():
     return SingleRequest('buildings_heating_electricity_curve', 'GET', value={'data':'curve',
-        'etm_key':'the_curve_key', 'type':'query'}, conversion='divide',
-        convert_with_value={'data':'technical.electricity_output_conversion.future',
-        'etm_key':'industry_chp_combined_cycle_gas_power_fuelmix', 'type':'node_property'})
+        'etm_key':'the_curve_key', 'type':'query'},
+        convert_with=[{'data':'technical.electricity_output_conversion.future',
+        'etm_key':'industry_chp_combined_cycle_gas_power_fuelmix', 'type':'node_property',
+        'conversion':'divide'}])
 
 def test_request_with_curve_divide(request_with_curve):
     # Check if the key is set
@@ -86,19 +87,20 @@ def test_request_without_correct_value_properties():
     # With an unknown conversion
     with pytest.raises(MissingRequestInfoException):
         SingleRequest('buildings_heating_electricity_curve','GET', value={'data':'curve',
-            'etm_key':'the_curve_key', 'type':'query'}, conversion='kittens',
-            convert_with_value={'data':'curve', 'etm_key':'the_query_key', 'type':'query'})
+            'etm_key':'the_curve_key', 'type':'query'},
+            convert_with=[{'data':'curve', 'etm_key':'the_query_key',
+            'conversion':'kittens', 'type':'query'}])
 
     # With a conversion that takes a second value, where this value is not specified
     with pytest.raises(MissingRequestInfoException):
         SingleRequest('buildings_heating_electricity_curve', 'GET', value={'data':'curve',
-            'etm_key':'the_curve_key', 'type':'query'}, conversion='divide')
+            'etm_key':'the_curve_key', 'type':'query'}, convert_with=[{'conversion':'divide'}])
 
 
 def test_values():
     request = SingleRequest('buildings_heating_electricity', 'SET', value={'data':'value',
-        'etm_key':'the_etm_key', 'type':'inputs'}, conversion='multiply',
-        convert_with_value={'key':'scaling_factor_x', 'value':500, 'type':'static'})
+        'etm_key':'the_etm_key', 'type':'inputs'},
+        convert_with=[{'key':'scaling_factor_x', 'conversion':'multiply','value':500, 'type':'static'}])
 
     request.set_value(10)
 
@@ -112,3 +114,24 @@ def test_values():
     request.calculate()
 
     assert request.value() == 10*500
+
+# def test_with_multiple_conversions():
+#     request = SingleRequest('buildings_heating_electricity', 'SET', value={'data':'value',
+#         'etm_key':'the_etm_key', 'type':'inputs'},
+#         convert_with=[
+#             {'key':'scaling_factor_x', 'conversion':'multiply','value':500, 'type':'static'},
+#             {'key':'scaling_factor_y', 'conversion':'multiply','value':10, 'type':'static'}
+#         ])
+
+#     request.set_value(10)
+
+#     request_values = request.values()
+#     # Only send the first value as required for calculation
+#     assert next(request_values).value() == 10
+#     with pytest.raises(StopIteration):
+#         next(request_values)
+
+
+#     request.calculate()
+
+#     assert request.value() == 10*500*10

--- a/tests/test_single_request.py
+++ b/tests/test_single_request.py
@@ -115,23 +115,24 @@ def test_values():
 
     assert request.value() == 10*500
 
-# def test_with_multiple_conversions():
-#     request = SingleRequest('buildings_heating_electricity', 'SET', value={'data':'value',
-#         'etm_key':'the_etm_key', 'type':'inputs'},
-#         convert_with=[
-#             {'key':'scaling_factor_x', 'conversion':'multiply','value':500, 'type':'static'},
-#             {'key':'scaling_factor_y', 'conversion':'multiply','value':10, 'type':'static'}
-#         ])
+def test_with_multiple_conversions():
+    request = SingleRequest('buildings_heating_electricity', 'SET', value={'data':'value',
+        'etm_key':'the_etm_key', 'type':'inputs'},
+        convert_with=[
+            {'key':'scaling_factor_x', 'conversion':'multiply', 'value':500, 'type':'static'},
+            {'key':'scaling_factor_y', 'conversion':'multiply', 'value':10, 'type':'static'},
+            {'key':'scaling_factor_y', 'conversion':'divide', 'value':5, 'type':'static'}
+        ])
 
-#     request.set_value(10)
+    request.set_value(10)
 
-#     request_values = request.values()
-#     # Only send the first value as required for calculation
-#     assert next(request_values).value() == 10
-#     with pytest.raises(StopIteration):
-#         next(request_values)
+    request_values = request.values()
+    # Only send the first value as required for calculation
+    assert next(request_values).value() == 10
+    with pytest.raises(StopIteration):
+        next(request_values)
 
 
-#     request.calculate()
+    request.calculate()
 
-#     assert request.value() == 10*500*10
+    assert request.value() == 10*500*10/5


### PR DESCRIPTION
Zo zou hij het moeten doen met meerdere conversies. De twee main methods zien er nu als volgt uit:

``` Python
retrieve_results(scenario_id: int, config_dict: dict) -> dict
```
voor GET;


``` Python
scale_copy_and_send(scenario_id: int, holon_outcomes: dict, config_dict: dict) -> int
```
voor SET;

De `config_dict` is de dict versie van de output JSON. Zie de test `fixtures` voor een voorbeeld hiervan. De `etm_api_url` wordt uit de `config_dict` geparsed. Het scenario ID niet, dat is een apart argument in de method. Mocht het toch een wens zijn is dat zo gepiept.

SET en GET kunnen (nog) niet door elkaar worden gebruikt. Vandaar dat een deel van de fixture is weggecomment. Ik ga hier zo een issue voor aanmaken.